### PR TITLE
feat: optional key for ResizableChild

### DIFF
--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -5,11 +5,15 @@ import 'package:flutter_resizable_container/src/resizable_size.dart';
 class ResizableChild {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
+    this.key,
     required this.child,
     this.size = const ResizableSize.expand(),
     this.maxSize,
     this.minSize,
   });
+
+  /// The (optional) key for this child Widget's container in the list.
+  final Key? key;
 
   /// The (optional) maximum size (in px) of this child Widget.
   final double? maxSize;

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -88,6 +88,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
                 for (var i = 0; i < widget.children.length; i++) ...[
                   // build the child
                   Builder(
+                    key: widget.children[i].key,
                     builder: (context) {
                       final height = _getChildSize(
                         index: i,


### PR DESCRIPTION
Adds an optional key to `ResizableChild` and modifies `ResizableContainer` to apply the key to the list-level Widget containing the child Widget.

This change allows adding a UniqueKey to each ResizableChild in a list to preserve the list order between rebuilds, as you would do with normal Widgets.
